### PR TITLE
ci(check): use reusable workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,19 +1,15 @@
-name: Whiskers Check
+name: whiskers
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:
     branches: [main]
 
 jobs:
-  check:
-    # change to ubuntu-latest after GitHub properly rolls out 24.04 (whiskers v2.5.1 depends on 24.04)
-    # ref: https://github.com/actions/runner-images/issues/10636
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: catppuccin/setup-whiskers@v1
-        with:
-          whiskers-version: 2.5.1
-      - run: whiskers react_native.tera --check
+  run:
+    uses: catppuccin/actions/.github/workflows/whiskers-check.yml@v1
+    with:
+      args: react_native.tera
+    secrets: inherit

--- a/react_native.tera
+++ b/react_native.tera
@@ -1,6 +1,6 @@
 ---
 whiskers:
-  version: 2.5.1
+  version: ^2.5.1
   matrix:
     - flavor
     - accent


### PR DESCRIPTION

We now have a reusable workflow for checking whiskers in CI, which is to be used
across the organisation. Note that whiskers will soon start to recommend `^` in
front of the version.
